### PR TITLE
add migration callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,17 +7,21 @@ var config = require('./config');
 var table = config['table'];
 var migrations_types = config['migrations_types'];
 
-function migration(conn, path) {
+function migration(conn, path, cb) {
+  if(cb === null)
+    cb = () => {};
+
   queryFunctions.run_query(conn, "CREATE TABLE IF NOT EXISTS `" + table + "` (`timestamp` varchar(254) NOT NULL UNIQUE)", function (res) {
-    handle(process.argv, conn, path);
+    handle(process.argv, conn, path, cb);
   });
 }
 
-function handle(argv, conn, path) {
+function handle(argv, conn, path, cb) {
   if (argv.length > 2 && argv.length <= 6) {
     if (argv[2] == 'add' && (argv[3] == 'migration' || argv[3] == 'seed')) {
       coreFunctions.add_migration(argv, path, function () {
         conn.end();
+        cb();
       });
     } else if (argv[2] == 'up') {
       var count = null;
@@ -28,6 +32,7 @@ function handle(argv, conn, path) {
       }
       coreFunctions.up_migrations(conn, count, path, function () {
         conn.end();
+        cb();
       });
     } else if (argv[2] == 'down') {
       var count = null;
@@ -36,16 +41,19 @@ function handle(argv, conn, path) {
       } else count = 1;
       coreFunctions.down_migrations(conn, count, path, function () {
         conn.end();
+        cb();
       });
     } else if (argv[2] == 'refresh') {
       coreFunctions.down_migrations(conn, 999999, path, function () {
         coreFunctions.up_migrations(conn, 999999, path, function () {
           conn.end();
+          cb();
         });
       });
     } else if (argv[2] == 'run' && migrations_types.indexOf(argv[4]) > -1) {
       coreFunctions.run_migration_directly(argv[3], argv[4], conn, path, function () {
         conn.end();
+        cb();
       });
     } else {
       throw new Error('command not found : ' + argv.join(" "));


### PR DESCRIPTION
* adds an optional callback to the migration function if the user does
not pass in a cb function it will create a noop() callback and operate
as it did previously.
* fix for #4 

Note, I'm not sure I'm following your style, so let me know and I can make any changes you'd like to have made.