### PR TITLE
TypeError: cb is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var table = config['table'];
 var migrations_types = config['migrations_types'];
 
 function migration(conn, path, cb) {
-  if(cb === null)
+  if(cb == null)
     cb = () => {};
 
   queryFunctions.run_query(conn, "CREATE TABLE IF NOT EXISTS `" + table + "` (`timestamp` varchar(254) NOT NULL UNIQUE)", function (res) {


### PR DESCRIPTION
In some cases the callback function equals undefined which doesn't equal `null`. Changing the `===` operator to `==` makes it check for both `null` as `undefined`.

This fixes the usage of `migration.init(connection, __dirname + '/migrations');` where otherwise `migration.init(connection, __dirname + '/migrations', function(){});` had to be used