### PR TITLE
Lower the length of timestamp column

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function migration(conn, path, cb) {
   if(cb == null)
     cb = () => {};
 
-  queryFunctions.run_query(conn, "CREATE TABLE IF NOT EXISTS `" + table + "` (`timestamp` varchar(254) NOT NULL UNIQUE)", function (res) {
+  queryFunctions.run_query(conn, "CREATE TABLE IF NOT EXISTS `" + table + "` (`timestamp` varchar(64) NOT NULL UNIQUE)", function (res) {
     handle(process.argv, conn, path, cb);
   });
 }


### PR DESCRIPTION
If a database has a limit of 1000 bytes for indexes, the timestamp column will in utf8 be too long and throw an error when trying to create the migration table. This suggested change lowers the limit to 64, which should be more than enough for this field.