### PR TITLE
Include all unapplied migrations in "up" command

### DIFF
--- a/core_functions.js
+++ b/core_functions.js
@@ -34,7 +34,7 @@ function add_migration(argv, path, cb) {
 function up_migrations(conn, max_count, path, cb) {
   queryFunctions.run_query(conn, "SELECT timestamp FROM " + table, function (results) {
     var file_paths = [];
-    var timestamps = results.map(r => r.timestamp);
+    var timestamps = results.map(r => parseInt(r.timestamp));
 
     fileFunctions.readFolder(path, function (files) {
       files.forEach(function (file) {

--- a/core_functions.js
+++ b/core_functions.js
@@ -32,19 +32,16 @@ function add_migration(argv, path, cb) {
 }
 
 function up_migrations(conn, max_count, path, cb) {
-  queryFunctions.run_query(conn, "SELECT timestamp FROM " + table + " ORDER BY timestamp DESC LIMIT 1", function (results) {
+  queryFunctions.run_query(conn, "SELECT timestamp FROM " + table, function (results) {
     var file_paths = [];
-    var max_timestamp = 0;
-    if (results.length) {
-      max_timestamp = results[0].timestamp;
-    }
+    var timestamps = results.map(r => r.timestamp);
 
     fileFunctions.readFolder(path, function (files) {
       files.forEach(function (file) {
         var timestamp_split = file.split("_", 1);
         if (timestamp_split.length) {
           var timestamp = parseInt(timestamp_split[0]);
-          if (Number.isInteger(timestamp) && timestamp.toString().length == 13 && timestamp > max_timestamp) {
+          if (Number.isInteger(timestamp) && timestamp.toString().length == 13 && !timestamps.includes(timestamp)) {
             file_paths.push({ timestamp : timestamp, file_path : file});
           }
         } else {


### PR DESCRIPTION
Currently, the script only applies migrations newer than the latest migration applied in the database. This causes issues for developers who apply newer migrations before older ones, like when you merge an older branch into a newer one that's already been migrated.

Example:

I have `master` with migrations `100`, `200`, and `300`. Someone forks this branch and creates migration `400`, but before they're finished working on their branch, I've already created migration `500` and pushed it to production. When their fork is merged back into `master`, migration `400` will never be applied because I've already applied `500`. This is an issue.

I wasn't sure what the best behavior is in this scenario. Maybe the script should _always_ apply migrations less than the highest applied migration, even when downgrading the database. This fix works for my uses though, and I may extend it in the future.

**New behavior:**
When upgrading the database, _all_ unapplied migrations will be included in the upgrade. Entering a limiting argument will limit these steps as normal.