### PR TITLE
29 dump routines

### DIFF
--- a/core_functions.js
+++ b/core_functions.js
@@ -118,7 +118,7 @@ function update_schema(conn, path, cb) {
   var conn_config = conn.config.connectionConfig;
   var filePath = path + '/' + 'schema.sql';
   fs.unlink(filePath, function() {
-    var cmd = "mysqldump --no-data ";
+    var cmd = "mysqldump --no-data --routines --events";
     if (conn_config.host) {
       cmd = cmd + " -h " + conn_config.host;
     }

--- a/test/core_functions.js
+++ b/test/core_functions.js
@@ -13,6 +13,74 @@ describe('core_functions.js', function() {
     testCommons(done);
   });
 
+  context('update schema', function () {
+    it('saves procedures', function (done) {
+      var name = 'test_procedure_3c71dcc968da49c4bfded38d9da26107';
+      mysql.query(`
+CREATE PROCEDURE ${name}()
+BEGIN
+  SELECT 1;
+END
+      `, function (error, results) {
+        if (error) throw error;
+        coreFunctions.update_schema(mysql, __dirname + '/migrations', function () {
+          mysql.query('DROP PROCEDURE ' + name, function (error, results) {
+            if (error) throw error;
+            const schema = fs.readFileSync(__dirname + '/migrations/schema.sql', { encoding: 'utf-8' });
+            assert.match(schema, new RegExp(name), 'Schema includes procedure');
+            done();
+          });
+        });
+      });
+    });
+    it('saves functions', (done) => {
+      var name = 'test_function_1391c8019b96453da1515ecd4a15a055';
+      mysql.query(`
+CREATE FUNCTION IF NOT EXISTS ${name}(a INT, b INT)
+RETURNS INT
+DETERMINISTIC
+BEGIN
+  DECLARE result INT;
+  SET result = a + b;
+  RETURN result;
+END
+      `, function (error, results) {
+        if (error) throw error;
+        coreFunctions.update_schema(mysql, __dirname + '/migrations', function () {
+          mysql.query('DROP FUNCTION IF EXISTS ' + name, function (error, results) {
+            if (error) throw error;
+            const schema = fs.readFileSync(__dirname + '/migrations/schema.sql', { encoding: 'utf-8' });
+            assert.match(schema, new RegExp(name), 'Schema includes function');
+            done();
+          });
+        });
+      });
+    });
+    it('saves events', (done) => {
+      var name = 'test_event_128c055bb3d64cde8dd88874d8f5f346';
+      mysql.query(`
+CREATE EVENT IF NOT EXISTS ${name}
+ON SCHEDULE
+  EVERY 1 DAY
+  STARTS CURRENT_TIMESTAMP
+DO
+BEGIN
+  SELECT 1;
+END;
+      `, function (error, results) {
+        if (error) throw error;
+        coreFunctions.update_schema(mysql, __dirname + '/migrations', function () {
+          mysql.query('DROP EVENT IF EXISTS ' + name, function (error, results) {
+            if (error) throw error;
+            const schema = fs.readFileSync(__dirname + '/migrations/schema.sql', { encoding: 'utf-8' });
+            assert.match(schema, new RegExp(name), 'Schema includes event');
+            done();
+          });
+        });
+      });
+    });
+  })
+
   context('add_migration', function () {
     it('should add migration', function (done) {
       var commands = ['node', 'migration', 'add', 'migration', 'create_user2'];


### PR DESCRIPTION
This change allows procedures, functions, and events to be dumped into schema.sql when running `schema-update`.

Resolves #29 (procedures & functions) 
Contributes to #30 (events)
