### PR TITLE
27 javascript migrations

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 module.exports = {
-  'table' : 'mysql_migrations_347ertt3e',
-  'migrations_types' : ['up', 'down']
+  'table': 'mysql_migrations_347ertt3e',
+  'migrations_types': ['up', 'down'],
+  'script_pattern': /\.(js|cjs|mjs)$/i
 };

--- a/file.js
+++ b/file.js
@@ -1,4 +1,5 @@
 var fs = require("fs");
+var config = require('./config');
 
 function validate_file_name(file_name) {
   var patt = /^[0-9a-zA-Z-_]+$/;
@@ -12,6 +13,8 @@ function readFolder(path, cb) {
     if (err) {
       throw err;
     }
+
+    files = files.filter(file => config.script_pattern.test(file));
 
     var schemaPath = files.indexOf("schema.sql");
     if (schemaPath > -1) {

--- a/test/file.js
+++ b/test/file.js
@@ -1,0 +1,39 @@
+var chai = require('chai');
+var fs = require('fs');
+
+var testCommons = require('./test_commons');
+var assert = require('assert');
+var file = require('../file');
+
+describe('file.js', function () {
+  before(function (done) {
+    testCommons(done);
+  });
+
+  context('readFolder', function () {
+    it('ignores text files', function (done) {
+      var name = 'fc0e8593-f0f0-45f0-8282-3c426836a486.txt';
+      fs.writeFileSync(__dirname + '/migrations/' + name, "test content", { encoding: 'utf-8' });
+      file.readFolder(__dirname + '/migrations', function (files) {
+        assert.ok(!files.includes(name), `Not contains ${name}`);
+        done();
+      });
+    });
+    it('reads JavaScript files', function (done) {
+      var name = 'fc0e8593-f0f0-45f0-8282-3c426836a486.js';
+      fs.writeFileSync(__dirname + '/migrations/' + name, "test content", { encoding: 'utf-8' });
+      file.readFolder(__dirname + '/migrations', function (files) {
+        assert.ok(files.includes(name), `Contains ${name}`);
+        done();
+      });
+    });
+    it('ignores schema.sql', function (done) {
+      var name = 'schema.sql';
+      fs.writeFileSync(__dirname + '/migrations/' + name, "test content", { encoding: 'utf-8' });
+      file.readFolder(__dirname + '/migrations', function (files) {
+        assert.ok(!files.includes(name), `Not contains ${name}`);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
All files (except schema.sql) were being processed in the migrations folder as if they were JavaScript files. Now all files are skipped unless they have a `.js`, `.mjs`, or `.cjs` file extension

Resolves #27