### PR TITLE
26 error report file name

### DIFF
--- a/query.js
+++ b/query.js
@@ -36,7 +36,10 @@ function execute_query(conn, path, final_file_paths, type, cb, run) {
     var current_file_path = path + "/" + file_name;
     
     var queries = require(current_file_path);
-    console.info(colors.green("Run: " + run + " Type: " + type.toUpperCase() + ": " +queries[type]));
+    console.info(colors.green(
+      `Run: ${run} Type: ${type.toUpperCase()}: ${file_name}`
+    ));
+    console.info(colors.gray(queries[type]));
 
     var timestamp_val = file_name.split("_", 1)[0];
     if (typeof(queries[type]) == 'string') {

--- a/test/query.js
+++ b/test/query.js
@@ -4,12 +4,48 @@ var queryFunctions = require('../query');
 var testCommons = require('./test_commons');
 var mysql = require('./mysql');
 var assert = require('assert');
+var fs = require('fs');
 
 var should = chai.should();
 
 describe('query.js', function() {
   before(function (done) {
     testCommons(done);
+  });
+  after(function (done) {
+    testCommons(done);
+  });
+
+  context('execute_query', function () {
+    it('should write file name', function (done) {
+      const name = '1_should_write_file_name.js';
+      fs.writeFileSync(
+        __dirname + '/migrations/' + name,
+        `module.exports={up: "select 1", down: "select 2"};`,
+        { encoding: 'utf-8' }
+      );
+
+      mysql.getConnection(function (err, connection) {
+        if (err) throw err;
+
+        var files = [{
+          timestamp: 1, file_path: name
+        }];
+        var oldInfo = console.info;
+        var loggedFile = false;
+        console.info = (arg1) => {
+          if (`${arg1}`.includes(name)) {
+            loggedFile = true;
+          }
+        };
+
+        queryFunctions.execute_query(mysql, __dirname + '/migrations', files, 'up', function () {
+          console.info = oldInfo.bind(console);
+          assert.ok(loggedFile, 'File name was logged.');
+          done();
+        });
+      });
+    })
   });
 
   context('updateRecords', function () {

--- a/test/test_commons.js
+++ b/test/test_commons.js
@@ -1,5 +1,6 @@
 var mysql = require('./mysql');
 var fs = require('fs');
+var config = require('../config');
 
 function deleteFolderRecursive(path) {
   if (fs.existsSync(path)) {
@@ -30,8 +31,11 @@ module.exports = function(cb) {
             if (error) throw error;
             connection.query("DROP TABLE IF EXISTS user5", function (error) {
               if (error) throw error;
-              deleteFolderRecursive(__dirname + '/migrations');
-              cb();
+              connection.query(`delete from ${config.table}`, function (error) {
+                if (error) throw error;
+                deleteFolderRecursive(__dirname + '/migrations');
+                cb();
+              })
             });
           });
         });


### PR DESCRIPTION
This issue resolved #26 where file names are now written out to the console since multiple files could have the same SQL queries.

One item of note is that I placed the SQL query itself on the next line afterwards and changed it to gray. If this is an issue, it can be changed to also be green. The main issue was to ensure that the file name appeared next to the type `UP` or `DOWN` since the SQL is often a multi-lined statement. In the provided screenshot, the sql command is one line `select 1` and in grey.

![image](https://github.com/kawadhiya21/mysql-migrations/assets/1164698/9f0bf4c7-0a51-4dd8-968d-bc7df7b8b86e)

